### PR TITLE
Add missing timeout parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
   atomic:
     description: If true, upgrade process rolls back changes made in case of failed upgrade. Defaults to true.
     required: false
+  timeout:
+    description: If set, wait this long for an upgrade to complete before rolling back.
+    required: false
   helm:
     description: Helm binary to execute, one of [helm, helm3].
     required: false


### PR DESCRIPTION
We see warnings wherever we set a timeout for our Helm releases because the parameter is not defined in `action.yml`, having been missed in the original PR: https://github.com/deliverybot/helm/pull/18. This change should fix that.

![image](https://github.com/standardbroadcast/helm-deploy-github-action/assets/979495/10510b6a-c190-45fe-acb2-26b11d5eb421)
