### PR TITLE
Update Dockerfile pinning version to v0.16.2 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     # Init version 2 helm:
     helm init --client-only && \
     # install helm s3 plugin
-    helm3 plugin install https://github.com/hypnoglow/helm-s3.git
+    helm3 plugin install https://github.com/hypnoglow/helm-s3 --version v0.16.2
 
 
 ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"


### PR DESCRIPTION
Due to this issue: https://github.com/hypnoglow/helm-s3/issues/488 , the plugin is not installing succesfully and preventing the charts to be puiblished in s3 from the `master` branch.

This is an attempt to pin the version to bypass this problem.

Tested locally with 

```
➜  ~ helm plugin install https://github.com/hypnoglow/helm-s3 --version v0.16.2     
Downloading and installing helm-s3 v0.16.2 ...
Checksum is valid.
Installed plugin: s3
```