### PR TITLE
Add conditional for setting app.name and app.value in helm-deploy-github-action.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ async function status(state) {
       log_url: url,
       target_url: url,
       headers: {
-        accept: 'application/vnd.github.ant-man-preview+json'
-      }
+        accept: "application/vnd.github.ant-man-preview+json",
+      },
     });
   } catch (error) {
     core.warning(`Failed to set deployment status: ${error.message}`);
@@ -93,7 +93,7 @@ function getValueFiles(files) {
   if (!Array.isArray(fileList)) {
     return [];
   }
-  return fileList.filter(f => !!f);
+  return fileList.filter((f) => !!f);
 }
 
 function getInput(name, options) {
@@ -101,7 +101,7 @@ function getInput(name, options) {
   const deployment = context.payload.deployment;
   let val = core.getInput(name.replace("_", "-"), {
     ...options,
-    required: false
+    required: false,
   });
   if (deployment) {
     if (deployment[name]) val = deployment[name];
@@ -123,7 +123,7 @@ function renderFiles(files, data) {
     `rendering value files [${files.join(",")}] with: ${JSON.stringify(data)}`
   );
   const tags = ["${{", "}}"];
-  const promises = files.map(async file => {
+  const promises = files.map(async (file) => {
     const content = await readFile(file, { encoding: "utf8" });
     const rendered = Mustache.render(content, data, {}, tags);
     await writeFile(file, rendered);
@@ -188,7 +188,6 @@ async function run() {
     core.debug(`param: repository = "${repository}"`);
     core.debug(`param: atomic = "${atomic}"`);
 
-
     // Setup command options and arguments.
     const args = [
       "upgrade",
@@ -202,27 +201,28 @@ async function run() {
 
     // Per https://helm.sh/docs/faq/#xdg-base-directory-support
     if (helm === "helm3") {
-      process.env.XDG_DATA_HOME = "/root/.helm/"
-      process.env.XDG_CACHE_HOME = "/root/.helm/"
-      process.env.XDG_CONFIG_HOME = "/root/.helm/"
-      process.env.HELM_CACHE_HOME="/root/.cache/helm"
-      process.env.HELM_CONFIG_HOME="/root/.config/helm"
-      process.env.HELM_DATA_HOME="/root/.local/share/helm"
-      process.env.HELM_PLUGINS="/root/.local/share/helm/plugins"
-      process.env.HELM_REGISTRY_CONFIG="/root/.config/helm/registry.json"
-      process.env.HELM_REPOSITORY_CACHE="/root/.cache/helm/repository"
-      process.env.HELM_REPOSITORY_CONFIG="/root/.config/helm/repositories.yaml"
+      process.env.XDG_DATA_HOME = "/root/.helm/";
+      process.env.XDG_CACHE_HOME = "/root/.helm/";
+      process.env.XDG_CONFIG_HOME = "/root/.helm/";
+      process.env.HELM_CACHE_HOME = "/root/.cache/helm";
+      process.env.HELM_CONFIG_HOME = "/root/.config/helm";
+      process.env.HELM_DATA_HOME = "/root/.local/share/helm";
+      process.env.HELM_PLUGINS = "/root/.local/share/helm/plugins";
+      process.env.HELM_REGISTRY_CONFIG = "/root/.config/helm/registry.json";
+      process.env.HELM_REPOSITORY_CACHE = "/root/.cache/helm/repository";
+      process.env.HELM_REPOSITORY_CONFIG =
+        "/root/.config/helm/repositories.yaml";
     } else {
-      process.env.HELM_HOME = "/root/.helm/"
+      process.env.HELM_HOME = "/root/.helm/";
     }
 
-    if (dryRun ==  "true") args.push("--dry-run");
-    if (appName) args.push(`--set=app.name=${appName}`);
-    if (version) args.push(`--set=app.version=${version}`);
+    if (dryRun == "true") args.push("--dry-run");
+    if (appName && chart === "app") args.push(`--set=app.name=${appName}`);
+    if (version && chart === "app") args.push(`--set=app.version=${version}`);
     if (chartVersion) args.push(`--version=${chartVersion}`);
     if (timeout) args.push(`--timeout=${timeout}`);
     if (repository) args.push(`--repo=${repository}`);
-    valueFiles.forEach(f => args.push(`--values=${f}`));
+    valueFiles.forEach((f) => args.push(`--values=${f}`));
     args.push("--values=./values.yml");
 
     // Special behaviour is triggered if the track is labelled 'canary'. The
@@ -256,7 +256,7 @@ async function run() {
     if (removeCanary) {
       core.debug(`removing canary ${appName}-canary`);
       await exec.exec(helm, deleteCmd(helm, namespace, `${appName}-canary`), {
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
       });
     }
     let output = "";
@@ -275,16 +275,16 @@ async function run() {
         outputStdline += data;
       },
     };
-    let command = "helm3 plugin list "
-    core.debug(command)
-    await exec.exec(command, "", options)
-    core.debug("output =%s",output)
-    core.debug("stdline =%s", outputStdline)
+    let command = "helm3 plugin list ";
+    core.debug(command);
+    await exec.exec(command, "", options);
+    core.debug("output =%s", output);
+    core.debug("stdline =%s", outputStdline);
 
     // Actually execute the deployment here.
     if (task === "remove") {
       await exec.exec(helm, deleteCmd(helm, namespace, release), {
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
       });
     } else {
       await exec.exec(helm, args);


### PR DESCRIPTION
## Context

The `helm-deploy-github-action` is currently setting `app.name` unconditionally when deploying, for example:  

```
helm3 upgrade production s3://nebula-helm-charts/charts/production/nebula-content/nebula-content-0.1.10-1754680952.tgz 
–install –wait –create-namespace –namespace=content 
–set=app.name=production –timeout=5m –values=./values.yml –atomic
```

This does not impact our existing applications because we do not have `app.name` in our charts.  However, when testing Jupyter Notebook, the values.yaml is validated against a schema, and this extra value prevents the deployment from succeeding.  

## Changes

- Added a conditional to only set `app.name` and `app.value` when `chart == app`.
- Performed minor code formatting adjustments.

## Notes

- The `app.name` and `app.value` settings are part of the generic embedded chart included in `helm-deploy-github-action`, originally intended for deploying a simple web app without a custom chart.
- This change maintains backward compatibility for anyone using the embedded chart in `helm-deploy-github-action`.
- If issues arise, rollback by reverting this PR.
